### PR TITLE
[2021-02-02][Authorization]용석:Token발급을 위한 Autorization Server 설정

### DIFF
--- a/AuthorizationServer/.gitignore
+++ b/AuthorizationServer/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### not using ###
+./.idea/workspace.xml

--- a/AuthorizationServer/pom.xml
+++ b/AuthorizationServer/pom.xml
@@ -55,6 +55,15 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
+            - Maven Central URL : https://mvnrepository.com/artifact/org.springframework.security.oauth.boot/spring-security-oauth2-autoconfigure
+            - [용석:2020-09-16] : Oauth방식을 이용하여 권한/인가 처리를 위한 spring-security-oauth2-autoconfigure 추가
+        -->
+        <dependency>
+            <groupId>org.springframework.security.oauth.boot</groupId>
+            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+            <version>2.1.0.RELEASE</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/AuthorizationServer/src/main/java/io/example/authorization/config/AuthorizationConfig.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/config/AuthorizationConfig.java
@@ -1,0 +1,24 @@
+package io.example.authorization.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+
+@Configuration
+@EnableAuthorizationServer
+public class AuthorizationConfig extends AuthorizationServerConfigurerAdapter {
+
+    // /oauth/authorize?response_type=code&client_id={client_id}&redirect_uri={redirect_uri}
+    @Override
+    public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
+        clients.inMemory()
+                .withClient("clientId")
+                .secret("{noop}clientSecret")
+                .authorizedGrantTypes("authorization_code", "refresh_token")
+                .redirectUris("http://localhost:8080/oauth/callback")
+                .scopes("read", "write")
+                .accessTokenValiditySeconds(60 * 10)
+        ;
+    }
+}

--- a/AuthorizationServer/src/main/java/io/example/authorization/config/SecurityConfig.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package io.example.authorization.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    // Http 요청에 대한 보안 설정
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable() // 토큰 발급 시 요청 Method인 POST 요청 임시 허용 설정 추가
+                .headers().frameOptions().disable()
+                .and()
+                .authorizeRequests().antMatchers("/oauth/**", "/oauth/callback", "/h2-console/*").permitAll()
+                .and()
+                .formLogin().and()
+                .httpBasic();
+    }
+
+    // InMemory환경에서 Token발급 대상인 사용자 정보 설정 추가
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.inMemoryAuthentication()
+                .withUser("choi-ys")
+                .password("{noop}password")
+                .roles("USER")
+        ;
+    }
+}


### PR DESCRIPTION
 - workspcae.xml gitignore 추가
 - Authorization Server설정을 위한 의존성 추가
  - spring-security-oauth2-autoconfigure dependency 추가
 - authorization_code방식의 인증 토큰 발급 설정
  - InMemory환경에서 authorization_code방식의 인증 토큰 발급을 위한 ClientDetailsServiceConfigurer 설정
 - WebSecurityConfigurerAdapter구현을 통한 Http요청의 인증/인가 및 사용자 인증 설정
  - 토큰 발급 시 요청 Method인 POST 요청 임시 허용 설정 추가
  - InMemory환경에서 Token발급 대상인 사용자 정보 설정 추가